### PR TITLE
Heroku button for easier installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The https://clojure.news webapp
 * Heroku(Free Plan)
 * mLab(Heroku Add-on)
 
+## Installation
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Contributing
 
 Feel free to jump in if you don't mind digging around, you can check out the [issues](https://github.com/ertugrulcetin/ClojureNews/issues)  page for ideas on what to work on.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+    "name": "Clojure News",
+    "description": "a Hacker News clone written in Clojure and ClojureScript",
+    "repository": "https://github.com/ertugrulcetin/ClojureNews",
+    "keywords": ["Clojure", "ClojureScript", "news", "hacker news"],
+    "addons": ["mongolab"]
+}


### PR DESCRIPTION
Adds a button to the README to automate the installation on Heroku and the configuration of the mLab addon.
